### PR TITLE
Memory Fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "threeify",
-  "version": "1.87.0",
+  "name": "@threekit/threeify",
+  "version": "1.89.1-alpha.0",
   "description": "Typescript 3D Library loosely based on three.js",
   "keywords": [
     "threeify",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@threekit/threeify",
-  "version": "1.89.1-alpha.0",
+  "version": "1.89.2-alpha.3",
   "description": "Typescript 3D Library loosely based on three.js",
   "keywords": [
     "threeify",

--- a/src/lib/engines/layerCompositor/LayerCompositor.ts
+++ b/src/lib/engines/layerCompositor/LayerCompositor.ts
@@ -161,22 +161,34 @@ export class LayerCompositor {
       this.offscreenSize.copy(offscreenSize);
       // console.log("updating framebuffer");
 
+      // write buffer
+
       if (this.offscreenWriteFramebuffer !== undefined) {
         this.offscreenWriteFramebuffer.dispose();
         this.offscreenWriteFramebuffer = undefined;
       }
-
-      this.offscreenWriteColorAttachment = this.makeColorMipmapAttachment();
       this.offscreenWriteFramebuffer = new Framebuffer(this.context);
+
+      if (this.offscreenWriteColorAttachment !== undefined) {
+        this.offscreenWriteColorAttachment.dispose();
+        this.offscreenWriteColorAttachment = undefined;
+      }
+      this.offscreenWriteColorAttachment = this.makeColorMipmapAttachment();
       this.offscreenWriteFramebuffer.attach(Attachment.Color0, this.offscreenWriteColorAttachment);
+
+      // read buffer
 
       if (this.offscreenReadFramebuffer !== undefined) {
         this.offscreenReadFramebuffer.dispose();
         this.offscreenReadFramebuffer = undefined;
       }
-
-      this.offscreenReadColorAttachment = this.makeColorMipmapAttachment();
       this.offscreenReadFramebuffer = new Framebuffer(this.context);
+
+      if (this.offscreenReadColorAttachment !== undefined) {
+        this.offscreenReadColorAttachment.dispose();
+        this.offscreenReadColorAttachment = undefined;
+      }
+      this.offscreenReadColorAttachment = this.makeColorMipmapAttachment();
       this.offscreenReadFramebuffer.attach(Attachment.Color0, this.offscreenReadColorAttachment);
 
       // frame buffer is pixel aligned with layer images.


### PR DESCRIPTION
- Fixed memory leak with layer comp not disposing of the offscreen buffers when new ones are allocates (when the layercomp is gets resized)
- Made LayerComp's load/discard methods behave predictably. Eg. if you call loadteximage2d and then immediately call discardTexImage2D without awaiting anything, it will actually discard the images. Previously, you had to wait for it to finish loading before discarding it.